### PR TITLE
Convert exec commands to full paths.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class phpbrew (
   }
 
   exec { 'init phpbrew':
-    command     => 'sudo /usr/bin/phpbrew init',
+    command     => '/usr/bin/sudo /usr/bin/phpbrew init',
     creates     => "/root/.phpbrew/bashrc",
     subscribe   => File['/usr/bin/phpbrew'],
     refreshonly => true,
@@ -80,7 +80,7 @@ class phpbrew (
   }
 
   exec { 'update basbrc':
-    command => "bash"
+    command => "/bin/bash"
   }
 
   file { "/root/.phpbrew/install_extension.sh":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,7 +37,7 @@ define phpbrew::install(
   }
 
   exec { "install php-${php_version}":
-    command     => "sudo PHPBREW_ROOT=${install_dir} /usr/bin/phpbrew install --old php-${php_version} +default +intl ${extra_params}",
+    command     => "/usr/bin/sudo PHPBREW_ROOT=${install_dir} /usr/bin/phpbrew install --old php-${php_version} +default +intl ${extra_params}",
     creates     => "${install_dir}/php/php-${php_version}/bin/php",
     timeout     => 0,
   }


### PR DESCRIPTION
Without this change, I get warnings like:
```
Error: Validation of Exec[install php-5.4.24] failed: 'sudo PHPBREW_ROOT=/opt/phpbrew /usr/bin/phpbrew install --old php-5.4.24 +default +intl ' is not qualified and no path was specified. Please qualify the command or specify a path. at /tmp/vagrant-puppet-2/modules-0/phpbrew/manifests/install.pp:39
Wrapped exception:
'sudo PHPBREW_ROOT=/opt/phpbrew /usr/bin/phpbrew install --old php-5.4.24 +default +intl ' is not qualified and no path was specified. Please qualify the command or specify a path.
```