### PR TITLE
Extension class fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppet module for phpbrew.
       $build_parameters = undef,
       $php_inis = undef,
       $install_dir = '/opt/phpbrew',
-    )
+    }
 
 
 ## Configuration
@@ -24,7 +24,7 @@ You can additional define the version (if the name should be different), the bui
         '/etc/php5/mods-available/custom.ini'
       ],
       $install_dir => '/opt/custom_dir',
-    )
+    }
 
 Default values:
 
@@ -40,7 +40,7 @@ Default values:
 
     define phpbrew::extension{ 'xdebug':
       $php_version = '5.3.27',
-    )
+    }
 
 Note the php version is required and the php version must be installed by php brew.
 

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -17,8 +17,9 @@
 define phpbrew::extension(
   $extension = undef,
   $php_version = undef,
-  $version = undef,
+  $version = 'stable',
   $install_dir = '/opt/phpbrew',
+  $reload_service = undef,
 ) {
   if ! $extension {
     $extension_name = $title
@@ -27,14 +28,14 @@ define phpbrew::extension(
   }
 
   if ! $php_version {
-    warning('No php version for extension given. Install aborted.')
-  } else {
-    exec { "phpbrew_extension_${extension_name}-${php_version}-${version}":
-      command => "/root/.phpbrew/install_extension.sh ${php_version} ${extension_name} ${version}",
-      timeout => 0,
-      user    => 'root',
-      creates => "${install_dir}/php/php-${php_version}/var/db/${extension_name}.ini",
-      notify  => Service['httpd']
-    }
+    fail('No php version for extension given. Install aborted.')
+  }
+
+  exec { "phpbrew_extension_${extension_name}-${php_version}-${version}":
+    command => "/root/.phpbrew/install_extension.sh ${php_version} ${extension_name} ${version}",
+    timeout => 0,
+    user    => 'root',
+    creates => "${install_dir}/php/php-${php_version}/var/db/${extension_name}.ini",
+    notify  => Service[$reload_service]
   }
 }


### PR DESCRIPTION
Just a few syntax errors in the README file.

For the extension class itself:
- Phpbrew uses 'stable' as the default version for extensions, we should
  use it here too.
- We can't assume httpd/apache is installed on the system, so we start
  with an undefined service to reload which will do nothing. To reload a
  service your should pass it explicitly. (I guess this is a breaking change)
- Cleanup if statement